### PR TITLE
Add width and height styles in chart renderer

### DIFF
--- a/src/it/designfuture/chartjs/BaseChartJSRenderer.js
+++ b/src/it/designfuture/chartjs/BaseChartJSRenderer.js
@@ -23,6 +23,15 @@ sap.ui.define(['jquery.sap.global'],
 		this.addOuterClasses(oRM, oControl);
 		oRM.writeClasses();
 		oRM.write(">");
+		
+		if (oControl.getHeight() !== undefined && oControl.getHeight() !== null) {
+			oRM.addStyle("height", oControl.getHeight());
+		}
+		if (oControl.getWidth() !== undefined && oControl.getWidth() !== null) {
+			oRM.addStyle("width", oControl.getWidth());
+		}
+		oRM.writeStyles();
+		
 		oRM.write("</canvas>");
 	};
 	


### PR DESCRIPTION
# Description
Currently the width and height properties are declared in the `BaseChartJS`, but ignored while rendering. This fix considers these properties during rendering to enable specific sizing of the chart controls. 