### PR TITLE
Fix hover event not firing

### DIFF
--- a/src/it/designfuture/chartjs/BaseChartJS.js
+++ b/src/it/designfuture/chartjs/BaseChartJS.js
@@ -806,6 +806,9 @@ sap.ui.define([
 				mode: this.getHoverMode(),
 				intersect: this.getHoverIntersect(),
 				animationDuration: this.getHoverAnimationDuration(),
+				onHover: function(event, activeElements) {
+					that.fireOnHover({ event, activeElements });
+				},
 			};
 			
 			var animationOptions = {


### PR DESCRIPTION
This fix will let the hover event fire again.
`globalOptions.onHover` is not working - `globalOptions.hover.onHover` seems to work fine.
See https://github.com/chartjs/Chart.js/issues/4296